### PR TITLE
fix: correct `table` align type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ export const tableCell = (kids?: Children) =>
   nodeWithChildren("tableCell", kids);
 export const tableRow = (kids?: Children) => nodeWithChildren("tableRow", kids);
 export const table = (
-  align?: ["left" | "right", "left" | "right" | "center"],
+  align?: ("left" | "right" | "center" | null)[],
   kids?: Children
 ) => ({ ...nodeWithChildren("table", kids), align });
 


### PR DESCRIPTION
The type for a `table` node's `align` value is wrong. Currently, it's a pair of strings (one is `"left" | "right"`, the other is `"left" | "right" | "center"` 😬) when it should be [an array of `"left" | "right" | "center" | null`](https://github.com/syntax-tree/mdast#aligntype).