### PR TITLE
Add support for the spread property in List and ListItem builders

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,10 +88,12 @@ export const heading = (depth: number, kids?: Children): Parent => {
 
 export const list = (
   ordered: "ordered" | "unordered",
-  kids: Children
+  kids: Children,
+  spread?: boolean,
 ): Parent => ({
   ...nodeWithChildren("list", kids),
-  ordered: ordered === "ordered"
+  ordered: ordered === "ordered",
+  spread,
 });
 export const listItem = (kids: Children): Parent =>
   nodeWithChildren("listItem", kids);

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,9 @@ export const list = (
 ): Parent => ({
   ...nodeWithChildren("list", kids),
   ordered: ordered === "ordered",
-  spread,
+  spread
 });
-export const listItem = (kids: Children): Parent =>
-  nodeWithChildren("listItem", kids);
+export const listItem = (kids: Children, spread?: boolean): Parent => ({
+  ...nodeWithChildren('listItem', kids),
+  spread
+});

--- a/test/acceptance.test.ts
+++ b/test/acceptance.test.ts
@@ -206,6 +206,47 @@ another thing
 *   second
 
 *   third`);
+
+    expectMd(
+      list(
+        'unordered',
+        listItem(
+          [
+            text('first'),
+            list('unordered', [
+              listItem(text('sub-first-a')),
+              listItem(text('sub-first-b')),
+              listItem(text('sub-first-c'))
+            ])
+          ],
+          true
+        )
+      )
+    ).to.eq(`*   first
+
+    *   sub-first-a
+    *   sub-first-b
+    *   sub-first-c`);
+
+    expectMd(
+      list(
+        'unordered',
+        listItem(
+          [
+            text('first'),
+            list('unordered', [
+              listItem(text('sub-first-a')),
+              listItem(text('sub-first-b')),
+              listItem(text('sub-first-c'))
+            ])
+          ],
+          false
+        )
+      )
+    ).to.eq(`*   first
+    *   sub-first-a
+    *   sub-first-b
+    *   sub-first-c`);
   });
 
   it('table', () => {

--- a/test/acceptance.test.ts
+++ b/test/acceptance.test.ts
@@ -166,6 +166,7 @@ another thing
     ).to.eq(`1.  first
 1.  second
 1.  third`);
+
     expectMd(
       list('unordered', [
         listItem(text('first')),
@@ -174,6 +175,36 @@ another thing
       ])
     ).to.eq(`*   first
 *   second
+*   third`);
+
+    expectMd(
+      list(
+        'unordered',
+        [
+          listItem(text('first')),
+          listItem(text('second')),
+          listItem(text('third'))
+        ],
+        false
+      )
+    ).to.eq(`*   first
+*   second
+*   third`);
+
+    expectMd(
+      list(
+        'unordered',
+        [
+          listItem(text('first')),
+          listItem(text('second')),
+          listItem(text('third'))
+        ],
+        true
+      )
+    ).to.eq(`*   first
+
+*   second
+
 *   third`);
   });
 


### PR DESCRIPTION
Hi! 

This PR adds support for the `spread` property when building List and ListItem nodes with mdast-builder. Test cases have also been added to verify that the new feature works. Fixes #77.

However, the resultant API probably needs some discussion first.

I didn't want to make a breaking change to the API; so at the moment this PR adds a new `boolean` parameter for `spread` at the end as an **optional** parameter. That way, existing users will be unaffected by the change since the builder function would behave as before if the last parameter is omitted. The new feature only comes into effect if the last parameter is provided by the user.

However, that means that the API for `List` and `ListItem` is no longer consistent with the other builder function APIs which accept `Children` as the final parameter.

Personally, I'm leaning towards having the API be consistent and move the optional `spread` parameter before the final `kids` parameter. Note that this would make the `kids` parameter optional for `List` and `ListItem` builders (and would close #75) - but that still maintains API consistency with the other builder functions (like `Image`, `Link` etc).

A review would be much appreciated @mike-north!